### PR TITLE
Add missing species to RegLand DB and create analysis-ready views

### DIFF
--- a/database/regland.sqlite
+++ b/database/regland.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2faddfa5911d29b2e74d782d778c89b3fe316eb24179e3de8e623444119f95b1
-size 1769345024
+oid sha256:2bfc09cb8a192f0bb9120099680edfe3aedf550c38f5468ca22c9818caec27ac
+size 1918914560

--- a/database/regland.sqlite
+++ b/database/regland.sqlite
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a995236dcce80025b18f0a4e05f2d3ab34d90447da3fbca0c02dab7ca3fe8d4b
-size 1307508736
+oid sha256:2faddfa5911d29b2e74d782d778c89b3fe316eb24179e3de8e623444119f95b1
+size 1769345024


### PR DESCRIPTION
## Summary
This PR addresses the missing species in the RegLand database and adds the analysis-ready views discussed in our Project Alpha planning.

## Changes Made

### Database Schema Updates
- ✅ **Added missing species** to  table:
  -  (Pig, susScr11) 
  -  (Chicken, grcg7b)
  -  (Macaque, rheMac10)

### Analysis-Ready Views  
- ✅ **** - High-confidence enhancers (requires score + Brain/Heart/Liver tissue)
- ✅ **** - Score required, includes tissue='unknown' for NULL values
- ✅ **** - CTCF sites with positional features and nearest gene info
- ✅ **** - Standardized GWAS source names for consistent analysis

### New Derived Tables
- ✅ **** - Backfilled method='nearest' and computed distances
- ✅ **** - Materialized promoter regions (±2kb around gene TSS)

### Data Quality Fixes
- ✅ **Backfilled ** NULL values to 50 (consistent with 50bp window)

### Performance Optimization
- ✅ **Added genomic location indexes** for species, chromosome, and position queries
- ✅ **Partial indexes** to accelerate high-confidence enhancer views
- ✅ **Mapping table indexes** for gene↔enhancer and SNP↔enhancer joins

## Verification
- ✅ All 5 species now present in species table
- ✅ 121,348 high-confidence enhancers available via 
- ✅ 1.9M gene-enhancer mappings with computed distances in   
- ✅ 195,977 promoter regions materialized
- ✅ 89,754 CTCF sites with context available
- ✅ Pig data confirmed: 17,602 genes and 800,013 enhancers

## Files Changed
-  - Updated with schema changes, views, and optimized indexes

This resolves the species inconsistencies and provides the analysis-ready views needed for reproducible Project Alpha workflows.